### PR TITLE
feat: order tracking, payment flow fixes, unified cart+tracking drawer

### DIFF
--- a/src/app/[slug]/checkout/page.tsx
+++ b/src/app/[slug]/checkout/page.tsx
@@ -27,6 +27,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import confetti from 'canvas-confetti';
 import { formatPrice } from '@/lib/format';
+import { saveActiveOrder } from '@/lib/guest-orders';
 
 const checkoutSchema = z.object({
   type: z.enum(['pickup', 'delivery', 'dine_in']),
@@ -87,6 +88,7 @@ export default function CheckoutPage() {
   const queryClient = useQueryClient();
   const [isSuccess, setIsSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [successOrderId, setSuccessOrderId] = useState<string | null>(null);
   const [loyaltyDiscount, setLoyaltyDiscount] = useState({ points: 0, amount: 0 });
   const [paymentMethod, setPaymentMethod] = useState<string>('');
   const [discountApplied, setDiscountApplied] = useState<{ code: string; amount: number } | null>(null);
@@ -135,12 +137,21 @@ export default function CheckoutPage() {
         guestEmail: values.guestEmail,
         guestPhone: values.guestPhone,
       }),
+      paymentMethod,
     };
 
     createOrder(payload, {
       onSuccess: (data) => {
         queryClient.invalidateQueries({ queryKey: ['loyalty-balance'] });
         queryClient.invalidateQueries({ queryKey: ['loyalty-transactions'] });
+
+        // Save active order for tracking
+        setSuccessOrderId(data.id);
+        saveActiveOrder({
+          orderId: data.id,
+          orderNumber: data.id.slice(-8).toUpperCase(),
+          slug: restaurant?.slug ?? '',
+        });
 
         if (paymentMethod === 'cash') {
           // Cash: show success immediately
@@ -208,6 +219,14 @@ export default function CheckoutPage() {
               className="w-full h-12 rounded-xl border border-gray-200 text-gray-700 font-semibold hover:bg-gray-50 transition-colors"
             >
               Ver estado de pedidos
+            </button>
+          )}
+          {successOrderId && (
+            <button
+              onClick={() => router.push(`${basePath}/track/${successOrderId}`)}
+              className="w-full h-12 rounded-xl border border-gray-200 text-gray-700 font-semibold hover:bg-gray-50 transition-colors"
+            >
+              Ver mi pedido
             </button>
           )}
           {isGuest && (
@@ -424,7 +443,7 @@ export default function CheckoutPage() {
               {isGuest && (
                 <Link href={`${basePath}/auth/register`} className="block mt-4">
                   <div className="flex items-center gap-3 p-3 rounded-xl bg-gray-50 border border-gray-100 hover:bg-gray-100 transition-colors">
-                    <div className="w-8 h-8 rounded-full bg-(--color-primary)/10 flex items-center justify-center shrink-0">
+                    <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
                       <User size={14} className="text-(--color-primary)" />
                     </div>
                     <p className="text-xs text-gray-500">

--- a/src/app/[slug]/order/[orderId]/page.tsx
+++ b/src/app/[slug]/order/[orderId]/page.tsx
@@ -150,7 +150,7 @@ export default function OrderTrackingPage() {
                     </Badge>
                   </div>
                   <p className="font-semibold text-gray-900">
-                    {formatPrice(item.price * item.quantity)}
+                    {formatPrice((item.unitPrice ?? item.price ?? 0) * item.quantity)}
                   </p>
                 </div>
               ))}

--- a/src/app/[slug]/payments/confirm/page.tsx
+++ b/src/app/[slug]/payments/confirm/page.tsx
@@ -1,14 +1,17 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useParams } from 'next/navigation';
 import { useRestaurant } from '@/providers/restaurant-provider';
+import { getActiveOrder } from '@/lib/guest-orders';
 import api from '@/lib/api';
 import { CheckCircle2, XCircle, Loader2 } from 'lucide-react';
 import Link from 'next/link';
 
 export default function PaymentConfirmPage() {
   const searchParams = useSearchParams();
+  const params = useParams();
+  const slug = params.slug as string;
   const { basePath } = useRestaurant();
   const tokenWs = searchParams.get('token_ws');
   const [status, setStatus] = useState<'loading' | 'success' | 'failed'>('loading');
@@ -21,7 +24,7 @@ export default function PaymentConfirmPage() {
 
     api.post('/payments/transbank/confirm', { token_ws: tokenWs })
       .then((res) => {
-        setStatus(res.data.status === 'CONFIRMED' ? 'success' : 'failed');
+        setStatus(res.data.status === 'confirmed' ? 'success' : 'failed');
       })
       .catch(() => setStatus('failed'));
   }, [tokenWs]);
@@ -43,11 +46,26 @@ export default function PaymentConfirmPage() {
             </div>
             <h1 className="text-xl font-bold text-gray-900 mb-2">¡Pago confirmado!</h1>
             <p className="text-sm text-gray-500 mb-6">Tu pedido ha sido procesado exitosamente.</p>
-            <Link href={`${basePath}/menu`}>
-              <button className="w-full h-11 rounded-xl bg-(--color-primary) text-white text-sm font-semibold hover:opacity-90 transition-all">
-                Volver al menú
-              </button>
-            </Link>
+            <div className="space-y-3">
+              {(() => {
+                const activeOrder = getActiveOrder(slug);
+                if (activeOrder) {
+                  return (
+                    <Link href={`${basePath}/track/${activeOrder.orderId}`}>
+                      <button className="w-full h-11 rounded-xl bg-(--color-primary) text-white text-sm font-semibold hover:opacity-90 transition-all">
+                        Ver mi pedido
+                      </button>
+                    </Link>
+                  );
+                }
+                return null;
+              })()}
+              <Link href={`${basePath}/menu`}>
+                <button className="w-full h-11 rounded-xl border border-gray-200 text-gray-700 text-sm font-semibold hover:bg-gray-50 transition-colors">
+                  Volver al menú
+                </button>
+              </Link>
+            </div>
           </div>
         )}
 

--- a/src/app/[slug]/payments/success/page.tsx
+++ b/src/app/[slug]/payments/success/page.tsx
@@ -1,17 +1,19 @@
 'use client';
 
 import { useState } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useParams } from 'next/navigation';
 import { useRestaurant } from '@/providers/restaurant-provider';
+import { getActiveOrder } from '@/lib/guest-orders';
 import { CheckCircle2, Clock } from 'lucide-react';
 import Link from 'next/link';
 
 export default function PaymentSuccessPage() {
   const searchParams = useSearchParams();
+  const params = useParams();
+  const slug = params.slug as string;
   const { basePath } = useRestaurant();
-  // orderId available for future use (e.g. order status polling)
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const _orderId = searchParams.get('orderId');
+  // Prefer orderId from query param (MP success URL includes it); fall back to localStorage
+  const urlOrderId = searchParams.get('orderId');
   const mpStatus = searchParams.get('status');
   const [status] = useState<'success' | 'pending'>(
     mpStatus === 'pending' ? 'pending' : 'success'
@@ -29,11 +31,26 @@ export default function PaymentSuccessPage() {
             <p className="text-sm text-gray-500 mb-6">
               Tu pedido ha sido procesado exitosamente con MercadoPago.
             </p>
-            <Link href={`${basePath}/menu`}>
-              <button className="w-full h-11 rounded-xl bg-(--color-primary) text-white text-sm font-semibold hover:opacity-90 transition-all">
-                Volver al menú
-              </button>
-            </Link>
+            <div className="space-y-3">
+              {(() => {
+                const trackingId = urlOrderId ?? getActiveOrder(slug)?.orderId;
+                if (trackingId) {
+                  return (
+                    <Link href={`${basePath}/track/${trackingId}`}>
+                      <button className="w-full h-11 rounded-xl bg-(--color-primary) text-white text-sm font-semibold hover:opacity-90 transition-all">
+                        Ver mi pedido
+                      </button>
+                    </Link>
+                  );
+                }
+                return null;
+              })()}
+              <Link href={`${basePath}/menu`}>
+                <button className="w-full h-11 rounded-xl border border-gray-200 text-gray-700 text-sm font-semibold hover:bg-gray-50 transition-colors">
+                  Volver al menú
+                </button>
+              </Link>
+            </div>
           </div>
         )}
 

--- a/src/app/[slug]/payments/webpay-return/route.ts
+++ b/src/app/[slug]/payments/webpay-return/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Webpay Plus redirects here via POST with token_ws in the form body.
+ * We extract the token and redirect (GET) to the confirm page with token_ws as a query param,
+ * so the client component can read it from searchParams.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const formData = await request.formData();
+  const tokenWs = formData.get('token_ws') as string | null;
+
+  if (!tokenWs) {
+    return NextResponse.redirect(new URL(`/${slug}/payments/confirm?error=no_token`, request.url));
+  }
+
+  return NextResponse.redirect(new URL(`/${slug}/payments/confirm?token_ws=${tokenWs}`, request.url));
+}
+
+/**
+ * Some Transbank flows may redirect via GET with token_ws as query param.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const tokenWs = request.nextUrl.searchParams.get('token_ws');
+
+  if (!tokenWs) {
+    return NextResponse.redirect(new URL(`/${slug}/payments/confirm?error=no_token`, request.url));
+  }
+
+  return NextResponse.redirect(new URL(`/${slug}/payments/confirm?token_ws=${tokenWs}`, request.url));
+}

--- a/src/app/[slug]/track/[orderId]/page.tsx
+++ b/src/app/[slug]/track/[orderId]/page.tsx
@@ -1,0 +1,448 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { useRestaurant } from '@/providers/restaurant-provider';
+import api from '@/lib/api';
+import { Order, OrderItem } from '@/types/order';
+import { Badge } from '@/components/ui/badge';
+import {
+  CheckCircle2,
+  Clock,
+  ChefHat,
+  Package,
+  XCircle,
+  Loader2,
+  CreditCard,
+  User,
+  Phone,
+  Mail,
+  MapPin,
+  UtensilsCrossed,
+  ShoppingBag,
+  Truck,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { formatPrice } from '@/lib/format';
+import Link from 'next/link';
+import Image from 'next/image';
+import { clearActiveOrder, saveActiveOrder } from '@/lib/guest-orders';
+
+/* ─── Config ────────────────────────────────────────────────────────────── */
+
+function getSteps(orderType: string) {
+  if (orderType === 'delivery') {
+    return [
+      { key: 'received', label: 'Recibido', icon: Clock },
+      { key: 'preparing', label: 'Preparando', icon: ChefHat },
+      { key: 'ready', label: 'Listo', icon: Package },
+      { key: 'on_the_way', label: 'En camino', icon: Truck },
+      { key: 'completed', label: 'Entregado', icon: CheckCircle2 },
+    ];
+  }
+  return [
+    { key: 'received', label: 'Recibido', icon: Clock },
+    { key: 'preparing', label: 'Preparando', icon: ChefHat },
+    { key: 'ready', label: 'Listo', icon: Package },
+    { key: 'completed', label: 'Entregado', icon: CheckCircle2 },
+  ];
+}
+
+const ITEM_STATUS: Record<string, { label: string; color: string }> = {
+  pending: { label: 'Pendiente', color: 'bg-yellow-100 text-yellow-700' },
+  in_preparation: { label: 'Preparando', color: 'bg-blue-100 text-blue-700' },
+  ready: { label: 'Listo', color: 'bg-green-100 text-green-700' },
+  delivered: { label: 'Entregado', color: 'bg-gray-100 text-gray-600' },
+};
+
+const ORDER_TYPE_LABELS: Record<string, { label: string; icon: typeof UtensilsCrossed }> = {
+  dine_in: { label: 'En el local', icon: UtensilsCrossed },
+  pickup: { label: 'Para retirar', icon: ShoppingBag },
+  delivery: { label: 'Delivery', icon: Truck },
+};
+
+const PAYMENT_METHOD_LABELS: Record<string, string> = {
+  webpay: 'Webpay',
+  mercadopago: 'MercadoPago',
+  cash: 'Efectivo',
+  pending: 'Pendiente',
+};
+
+const PAYMENT_STATUS_LABELS: Record<string, { label: string; color: string }> = {
+  pending: { label: 'Pendiente', color: 'text-amber-600' },
+  paid: { label: 'Pagado', color: 'text-emerald-600' },
+  failed: { label: 'Fallido', color: 'text-red-600' },
+  refunded: { label: 'Reembolsado', color: 'text-gray-600' },
+};
+
+const TERMINAL_STATUSES = new Set(['completed', 'cancelled']);
+
+function getStepIndex(order: Order): number {
+  if (order.status === 'cancelled') return -1;
+  if (order.status === 'completed') {
+    return order.type === 'delivery' ? 4 : 3;
+  }
+  if (order.status === 'out_for_delivery') return 3; // delivery only
+  if (order.status === 'ready') return 2;
+  if (order.status === 'pending' || order.status === 'awaiting_payment') return 0;
+  // in_progress
+  if (order.items.some((i) => i.status === 'ready' || i.status === 'delivered')) return 2;
+  return 1;
+}
+
+function getStatusMessage(order: Order): string {
+  switch (order.status) {
+    case 'awaiting_payment':
+      return 'Estamos verificando tu pago. Esta pagina se actualizara automaticamente.';
+    case 'pending':
+      return 'Tu pedido fue recibido y esta en espera.';
+    case 'in_progress': {
+      const ready = order.items?.filter((i) => i.status === 'ready' || i.status === 'delivered').length ?? 0;
+      if (ready > 0) return `${ready} de ${order.items?.length} items listos.`;
+      return 'Nuestro equipo esta trabajando en tu pedido.';
+    }
+    case 'ready':
+      return order.type === 'delivery'
+        ? 'Tu pedido está listo. Esperando al repartidor.'
+        : order.type === 'pickup'
+          ? 'Tu pedido está listo para retirar.'
+          : 'Tu pedido está listo.';
+    case 'out_for_delivery':
+      return 'Tu pedido va en camino.';
+    case 'completed':
+      return 'Todos los items fueron entregados.';
+    case 'cancelled':
+      return 'Este pedido fue cancelado.';
+    default:
+      return '';
+  }
+}
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString('es-CL', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/* ─── Page ──────────────────────────────────────────────────────────────── */
+
+export default function GuestTrackingPage() {
+  const params = useParams();
+  const slug = params.slug as string;
+  const orderId = params.orderId as string;
+  const { basePath, restaurant } = useRestaurant();
+
+  const { data: order, isLoading, isError } = useQuery({
+    queryKey: ['guest-order', orderId],
+    queryFn: () =>
+      api.get<Order>(`/storefront/${slug}/orders/${orderId}`).then((r) => r.data),
+    staleTime: 5_000,
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data) return 10_000;
+      return TERMINAL_STATUSES.has(data.status) ? false : 10_000;
+    },
+  });
+
+  useEffect(() => {
+    if (!order) return;
+    if (TERMINAL_STATUSES.has(order.status)) {
+      clearActiveOrder(orderId);
+    } else {
+      saveActiveOrder({
+        orderId,
+        orderNumber: order.orderNumber ?? orderId.slice(-8).toUpperCase(),
+        slug,
+      });
+    }
+  }, [order?.status, orderId, slug]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <Loader2 className="animate-spin h-8 w-8 text-gray-300" />
+      </div>
+    );
+  }
+
+  if (isError || !order) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center p-6 bg-gray-50">
+        <XCircle size={40} className="text-gray-300 mb-3" />
+        <p className="text-gray-500 font-medium">Pedido no encontrado</p>
+        <Link href={`${basePath}/menu`} className="text-sm text-(--color-primary) font-semibold mt-3 hover:underline">
+          Volver al menu
+        </Link>
+      </div>
+    );
+  }
+
+  const steps = getSteps(order.type);
+  const stepIndex = getStepIndex(order);
+  const statusMessage = getStatusMessage(order);
+  const orderNumber = order.orderNumber ?? orderId.slice(-8).toUpperCase();
+  const orderType = ORDER_TYPE_LABELS[order.type];
+  const paymentMethod = PAYMENT_METHOD_LABELS[order.paymentMethod ?? 'pending'] ?? order.paymentMethod;
+  const paymentStatus = PAYMENT_STATUS_LABELS[order.paymentStatus ?? 'pending'];
+  const isCancelled = order.status === 'cancelled';
+  const isAwaitingPayment = order.status === 'awaiting_payment';
+
+  return (
+    <div className="min-h-screen bg-gray-50 pb-24">
+      <div className="max-w-lg mx-auto px-4 py-6 space-y-4">
+
+        {/* Restaurant header */}
+        <div className="flex items-center gap-3">
+          {(restaurant?.logoUrl || order.restaurant?.logoUrl) && (
+            <div className="relative w-10 h-10 rounded-xl overflow-hidden bg-gray-100 shrink-0">
+              <Image
+                src={restaurant?.logoUrl || order.restaurant?.logoUrl || ''}
+                alt={restaurant?.name || order.restaurant?.name || ''}
+                fill
+                className="object-cover"
+              />
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <p className="text-xs text-gray-400 font-semibold uppercase tracking-wider">Seguimiento</p>
+            <p className="text-sm font-bold text-gray-900 truncate">
+              {restaurant?.name || order.restaurant?.name}
+            </p>
+          </div>
+        </div>
+
+        {/* Order number + type badge */}
+        <div className="bg-white rounded-2xl p-5 shadow-sm">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-xs text-gray-400 font-semibold uppercase tracking-wider mb-0.5">Pedido</p>
+              <p className="text-2xl font-black text-gray-900 font-mono tracking-wider leading-tight">
+                #{orderNumber}
+              </p>
+              <p className="text-xs text-gray-400 mt-1">{formatDate(order.createdAt)}</p>
+            </div>
+            {orderType && (
+              <div className="flex items-center gap-1.5 bg-gray-100 rounded-full px-3 py-1.5 shrink-0">
+                <orderType.icon size={13} className="text-gray-500" />
+                <span className="text-xs font-semibold text-gray-600">{orderType.label}</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Awaiting payment */}
+        {isAwaitingPayment && (
+          <div className="bg-amber-50 border border-amber-200 rounded-2xl p-4 flex items-center gap-3">
+            <Loader2 className="animate-spin text-amber-500 shrink-0" size={20} />
+            <p className="text-sm font-medium text-amber-800">{statusMessage}</p>
+          </div>
+        )}
+
+        {/* Stepper */}
+        {!isAwaitingPayment && !isCancelled && (
+          <div className="bg-white rounded-2xl p-5 shadow-sm">
+            <div className="relative flex justify-between items-start">
+              {steps.map((step, idx) => {
+                const isCurrent = idx === stepIndex;
+                const isDone = idx < stepIndex;
+                const isActive = idx <= stepIndex;
+                const StepIcon = isDone ? CheckCircle2 : step.icon;
+                return (
+                  <div key={step.key} className="flex flex-col items-center relative z-10" style={{ width: `${100 / steps.length}%` }}>
+                    <div
+                      className={cn(
+                        'w-10 h-10 rounded-full flex items-center justify-center transition-all duration-300',
+                        isCurrent
+                          ? 'text-white shadow-md'
+                          : isDone
+                            ? 'text-white'
+                            : 'bg-gray-100 text-gray-300 border border-gray-200',
+                      )}
+                      style={{
+                        backgroundColor:
+                          isActive ? 'var(--color-primary)' : undefined,
+                        opacity: isDone && !isCurrent ? 0.6 : undefined,
+                      }}
+                    >
+                      <StepIcon className="h-5 w-5" />
+                    </div>
+                    <span
+                      className={cn(
+                        'text-[10px] mt-2 font-semibold text-center leading-tight px-0.5',
+                        isActive ? 'text-gray-800' : 'text-gray-400',
+                      )}
+                    >
+                      {step.label}
+                    </span>
+                  </div>
+                );
+              })}
+              {/* Progress line */}
+              <div
+                className="absolute top-5 h-0.5 bg-gray-100 rounded-full"
+                style={{ width: '75%', left: '12.5%' }}
+              >
+                <div
+                  className="h-full rounded-full transition-all duration-500 ease-in-out"
+                  style={{
+                    backgroundColor: 'var(--color-primary)',
+                    width: `${Math.max(0, (stepIndex / (steps.length - 1)) * 100)}%`,
+                  }}
+                />
+              </div>
+            </div>
+            {statusMessage && (
+              <p className="text-xs text-gray-400 text-center mt-4">{statusMessage}</p>
+            )}
+          </div>
+        )}
+
+        {/* Cancelled */}
+        {isCancelled && (
+          <div className="bg-red-50 border border-red-200 rounded-2xl p-4 flex items-center gap-3">
+            <XCircle className="text-red-500 shrink-0" size={20} />
+            <p className="text-sm font-medium text-red-700">{statusMessage}</p>
+          </div>
+        )}
+
+        {/* Order info: customer + payment */}
+        <div className="bg-white rounded-2xl shadow-sm divide-y divide-gray-100">
+          {/* Customer info */}
+          {(order.guestName || order.guestEmail || order.guestPhone || order.table) && (
+            <div className="p-4 space-y-2.5">
+              <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Cliente</p>
+              {order.guestName && (
+                <div className="flex items-center gap-2.5">
+                  <User size={14} className="text-gray-400 shrink-0" />
+                  <span className="text-sm text-gray-700">{order.guestName}</span>
+                </div>
+              )}
+              {order.guestEmail && (
+                <div className="flex items-center gap-2.5">
+                  <Mail size={14} className="text-gray-400 shrink-0" />
+                  <span className="text-sm text-gray-700">{order.guestEmail}</span>
+                </div>
+              )}
+              {order.guestPhone && (
+                <div className="flex items-center gap-2.5">
+                  <Phone size={14} className="text-gray-400 shrink-0" />
+                  <span className="text-sm text-gray-700">{order.guestPhone}</span>
+                </div>
+              )}
+              {order.table && (
+                <div className="flex items-center gap-2.5">
+                  <MapPin size={14} className="text-gray-400 shrink-0" />
+                  <span className="text-sm text-gray-700">Mesa #{order.table.tableNumber}</span>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Payment info */}
+          <div className="p-4 space-y-2.5">
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Pago</p>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2.5">
+                <CreditCard size={14} className="text-gray-400 shrink-0" />
+                <span className="text-sm text-gray-700">{paymentMethod}</span>
+              </div>
+              {paymentStatus && (
+                <span className={cn('text-xs font-semibold', paymentStatus.color)}>
+                  {paymentStatus.label}
+                </span>
+              )}
+            </div>
+            {order.transaction?.externalId && (
+              <div className="flex items-center gap-2.5">
+                <span className="text-xs text-gray-400 shrink-0 w-3.5" />
+                <span className="text-xs text-gray-400 font-mono">
+                  Tx: {order.transaction.externalId}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Items */}
+        <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+          <div className="px-4 py-3.5 border-b border-gray-100 flex items-center justify-between">
+            <h2 className="font-bold text-gray-900 text-sm">Items del pedido</h2>
+            <span className="text-xs text-gray-400">{order.items.length} items</span>
+          </div>
+          <div className="divide-y divide-gray-50">
+            {order.items.map((item: OrderItem) => {
+              const status = ITEM_STATUS[item.status];
+              return (
+                <div key={item.id} className="px-4 py-3 flex gap-3">
+                  {item.productImage ? (
+                    <div className="relative w-11 h-11 rounded-lg overflow-hidden bg-gray-100 shrink-0">
+                      <Image
+                        src={item.productImage}
+                        alt={item.productName ?? ''}
+                        fill
+                        className="object-cover"
+                      />
+                    </div>
+                  ) : (
+                    <div className="w-11 h-11 rounded-lg bg-gray-100 flex items-center justify-center shrink-0">
+                      <Package size={16} className="text-gray-300" />
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-start justify-between gap-2">
+                      <p className="text-sm text-gray-800 truncate">
+                        <span className="font-bold">{item.quantity}x</span>{' '}
+                        {item.productName ?? 'Producto'}
+                      </p>
+                      <p className="text-sm font-semibold text-gray-900 shrink-0 tabular-nums">
+                        {formatPrice(item.unitPrice * item.quantity)}
+                      </p>
+                    </div>
+                    {item.comment && (
+                      <p className="text-xs text-gray-400 italic mt-0.5 truncate">
+                        &quot;{item.comment}&quot;
+                      </p>
+                    )}
+                    {status && (
+                      <Badge className={cn('text-[10px] font-medium h-5 mt-1.5 border-0', status.color)}>
+                        {status.label}
+                      </Badge>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Total */}
+          <div className="px-4 py-3.5 bg-gray-50 flex justify-between items-center border-t border-gray-100">
+            <span className="text-sm text-gray-500 font-medium">Total</span>
+            <span className="text-lg font-bold text-gray-900">
+              {formatPrice(order.total ?? 0)}
+            </span>
+          </div>
+        </div>
+
+        {/* Polling notice */}
+        {!TERMINAL_STATUSES.has(order.status) && !isAwaitingPayment && (
+          <p className="text-center text-[11px] text-gray-400">
+            Se actualiza automaticamente cada 10 segundos
+          </p>
+        )}
+
+        {/* Back to menu */}
+        <Link href={`${basePath}/menu`} className="block">
+          <button className="w-full h-11 rounded-xl border border-gray-200 text-gray-600 font-semibold hover:bg-gray-100 transition-colors text-sm">
+            Volver al menu
+          </button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[slug]/track/page.tsx
+++ b/src/app/[slug]/track/page.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useRestaurant } from '@/providers/restaurant-provider';
+import api from '@/lib/api';
+import { Search, Loader2, ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { getActiveOrder } from '@/lib/guest-orders';
+
+
+export default function TrackLookupPage() {
+  const params = useParams();
+  const slug = params.slug as string;
+  const router = useRouter();
+  const { basePath, restaurant } = useRestaurant();
+
+  const [orderNumber, setOrderNumber] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  const activeOrder = hasMounted ? getActiveOrder(slug) : null;
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = orderNumber.trim().toUpperCase();
+    if (trimmed.length < 4) {
+      setError('Ingresa al menos 4 caracteres del número de pedido');
+      return;
+    }
+
+    setError(null);
+    setIsSearching(true);
+
+    try {
+      const res = await api.get(`/storefront/${slug}/orders/lookup`, {
+        params: { orderNumber: trimmed },
+      });
+      router.push(`${basePath}/track/${res.data.id}`);
+    } catch {
+      setError('No encontramos un pedido con ese número. Verifica e intenta de nuevo.');
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-lg mx-auto px-4 py-8 space-y-5">
+
+        {/* Restaurant branding */}
+        <div className="flex flex-col items-center gap-3 pb-2">
+          {restaurant?.logoUrl ? (
+            <Image
+              src={restaurant.logoUrl}
+              alt={restaurant.name}
+              width={72}
+              height={72}
+              className="h-14 w-auto object-contain"
+              priority
+            />
+          ) : (
+            <div className="w-14 h-14 rounded-2xl bg-primary/10 flex items-center justify-center">
+              <span className="text-xl font-black text-(--color-primary)">
+                {restaurant?.name?.charAt(0) ?? '?'}
+              </span>
+            </div>
+          )}
+          <h1 className="text-base font-bold text-gray-800 tracking-tight">
+            {restaurant?.name}
+          </h1>
+        </div>
+
+        {/* Lookup card */}
+        <div className="bg-white rounded-2xl p-6 shadow-sm">
+          <div className="mb-5">
+            <h2 className="text-lg font-bold text-gray-900 mb-1">
+              Seguir mi pedido
+            </h2>
+            <p className="text-sm text-gray-400 leading-relaxed">
+              Ingresa el número de pedido que recibiste en tu comprobante.
+            </p>
+          </div>
+
+          <form onSubmit={handleSearch} className="space-y-3">
+            <div>
+              <label className="block text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+                Numero de pedido
+              </label>
+              <div className="relative">
+                <input
+                  type="text"
+                  value={orderNumber}
+                  onChange={(e) => {
+                    setOrderNumber(e.target.value.toUpperCase());
+                    setError(null);
+                  }}
+                  placeholder="Ej: A1B2C3D4"
+                  maxLength={8}
+                  autoComplete="off"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  className="
+                    w-full h-12 px-4 pr-12 rounded-xl
+                    border border-gray-200
+                    text-center text-lg font-mono font-bold tracking-widest text-gray-900
+                    placeholder:text-gray-300 placeholder:tracking-normal placeholder:font-normal placeholder:text-sm
+                    focus:outline-none focus:ring-2 focus:ring-(--color-primary)/20 focus:border-(--color-primary)
+                    transition-shadow bg-white
+                  "
+                />
+                <Search
+                  size={16}
+                  className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"
+                  aria-hidden="true"
+                />
+              </div>
+            </div>
+
+            {error && (
+              <p className="text-sm text-red-500 text-center" role="alert">
+                {error}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={isSearching || orderNumber.trim().length < 4}
+              className="
+                w-full h-12 rounded-xl
+                bg-(--color-primary) text-white font-semibold text-sm
+                hover:opacity-90 active:scale-[0.98] transition-all
+                disabled:opacity-40 disabled:cursor-not-allowed
+                flex items-center justify-center gap-2
+              "
+            >
+              {isSearching ? (
+                <>
+                  <Loader2 size={16} className="animate-spin" aria-hidden="true" />
+                  Buscando...
+                </>
+              ) : (
+                'Buscar pedido'
+              )}
+            </button>
+          </form>
+        </div>
+
+        {/* Active order quick-access */}
+        {activeOrder && (
+          <div className="bg-white rounded-2xl p-4 shadow-sm">
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+              Pedido en curso
+            </p>
+            <button
+              onClick={() => router.push(`${basePath}/track/${activeOrder.orderId}`)}
+              className="w-full flex items-center justify-between gap-3 group"
+              aria-label={`Ver estado del pedido #${activeOrder.orderNumber}`}
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <div
+                  className="w-2.5 h-2.5 rounded-full shrink-0 animate-pulse bg-green-500"
+                  aria-hidden="true"
+                />
+                <span className="font-bold text-gray-900 font-mono tracking-wider truncate">
+                  #{activeOrder.orderNumber}
+                </span>
+                <span className="text-sm text-gray-400 truncate">
+                  En curso
+                </span>
+              </div>
+              <span className="text-sm text-(--color-primary) font-semibold shrink-0 group-hover:underline">
+                Ver estado
+              </span>
+            </button>
+          </div>
+        )}
+
+        {/* Back to menu */}
+        <div className="text-center pt-1">
+          <Link
+            href={`${basePath}/menu`}
+            className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <ArrowLeft size={14} aria-hidden="true" />
+            Volver al menú
+          </Link>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/src/components/cart/CartDrawer.tsx
+++ b/src/components/cart/CartDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useCartStore } from '@/stores/cart-store';
 import { useRestaurant } from '@/providers/restaurant-provider';
 import {
@@ -16,6 +16,9 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { formatPrice } from '@/lib/format';
+import { getActiveOrdersForSlug, ActiveOrder } from '@/lib/guest-orders';
+import { cn } from '@/lib/utils';
+import { OrderTrackingTab } from '@/components/cart/OrderTrackingTab';
 
 interface CartDrawerProps {
   isOpen: boolean;
@@ -31,10 +34,27 @@ export function CartDrawer({ isOpen, onClose }: CartDrawerProps) {
     getTotal,
     getItemCount,
   } = useCartStore();
-  const { basePath } = useRestaurant();
+  const { basePath, slug } = useRestaurant();
 
   const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
   const [commentDraft, setCommentDraft] = useState('');
+  const [tab, setTab] = useState<'cart' | 'orders'>('cart');
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => { setHasMounted(true); }, []);
+
+  const activeOrders: ActiveOrder[] = hasMounted && slug ? getActiveOrdersForSlug(slug) : [];
+  const hasActiveOrders = activeOrders.length > 0;
+
+  // Auto-switch tab when drawer opens
+  useEffect(() => {
+    if (!isOpen) return;
+    if (items.length === 0 && hasActiveOrders) {
+      setTab('orders');
+    } else {
+      setTab('cart');
+    }
+  }, [isOpen, items.length, hasActiveOrders]);
 
   const startEditComment = (productId: string, currentComment: string | undefined) => {
     setEditingCommentId(productId);
@@ -49,144 +69,225 @@ export function CartDrawer({ isOpen, onClose }: CartDrawerProps) {
   return (
     <Sheet open={isOpen} onOpenChange={onClose}>
       <SheetContent side="right" className="w-full sm:max-w-md p-0 flex flex-col gap-0 border-l [&>button]:hidden">
-        <SheetHeader className="px-6 py-5 border-b flex flex-row items-center justify-between space-y-0">
-          <SheetTitle className="text-lg font-bold flex items-center gap-2.5">
-            Tu Carrito
-            {getItemCount() > 0 && (
-              <span className="bg-(--color-primary) text-white text-[11px] font-bold px-2 py-0.5 rounded-full">
-                {getItemCount()}
-              </span>
-            )}
-          </SheetTitle>
-          <button onClick={onClose} className="p-1.5 -mr-1.5 hover:bg-gray-100 rounded-lg transition-colors" aria-label="Cerrar carrito">
-            <X size={20} className="text-gray-400" />
-          </button>
+
+        {/* Accessible title for screen readers (always present) */}
+        <SheetHeader className="sr-only">
+          <SheetTitle>{hasActiveOrders ? 'Tu Actividad' : 'Tu Carrito'}</SheetTitle>
         </SheetHeader>
 
-        <div className="flex-1 overflow-hidden">
-          {items.length === 0 ? (
-            <div className="h-full flex flex-col items-center justify-center p-8 text-center">
-              <div className="bg-muted p-6 rounded-full mb-4">
-                <ShoppingBag size={48} className="text-muted-foreground/40" />
-              </div>
-              <h3 className="text-lg font-semibold mb-2">Tu carrito está vacío</h3>
-              <p className="text-muted-foreground mb-6">¿Hambre? ¡Agrega algo delicioso!</p>
-              <Button
+        {/* Visible header — tabs when has active orders, plain title otherwise */}
+        {hasActiveOrders ? (
+          <div className="px-6 py-4 border-b shrink-0" role="presentation">
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-lg font-bold">Tu Actividad</h2>
+              <button
                 onClick={onClose}
-                className="rounded-full bg-(--color-primary) hover:bg-(--color-primary) opacity-90 hover:opacity-100 px-8"
+                className="p-1.5 -mr-1.5 hover:bg-gray-100 rounded-lg transition-colors"
+                aria-label="Cerrar"
               >
-                Volver al menú
-              </Button>
+                <X size={20} className="text-gray-400" />
+              </button>
             </div>
-          ) : (
-            <ScrollArea className="h-full px-6">
-              <div className="py-6 space-y-6">
-                {items.map((item) => (
-                  <div key={item.product.id} className="flex gap-4">
-                    <div className="relative h-20 w-20 shrink-0">
-                      {item.product.imageUrl ? (
-                        <Image
-                          src={item.product.imageUrl}
-                          alt={item.product.name}
-                          fill
-                          className="object-cover rounded-lg"
-                        />
-                      ) : (
-                        <div className="h-full w-full bg-muted rounded-lg flex items-center justify-center text-muted-foreground text-xs">
-                          Sin imagen
-                        </div>
-                      )}
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex justify-between items-start mb-1">
-                        <h4 className="font-semibold text-foreground truncate pr-2">
-                          {item.product.name}
-                        </h4>
-                        <button
-                          onClick={() => removeItem(item.product.id)}
-                          className="text-muted-foreground hover:text-red-500 transition-colors"
-                          aria-label="Eliminar producto"
-                        >
-                          <Trash2 size={16} />
-                        </button>
-                      </div>
+            <div className="flex gap-1 bg-gray-100 rounded-xl p-1">
+              <button
+                onClick={() => setTab('cart')}
+                className={cn(
+                  'flex-1 py-2 px-3 rounded-lg text-sm font-semibold transition-all duration-200',
+                  tab === 'cart'
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-500 hover:text-gray-700'
+                )}
+              >
+                Carrito
+                {getItemCount() > 0 && (
+                  <span
+                    className={cn(
+                      'ml-1.5 text-[10px] font-bold px-1.5 py-0.5 rounded-full',
+                      tab === 'cart'
+                        ? 'bg-(--color-primary) text-white'
+                        : 'bg-gray-200 text-gray-600'
+                    )}
+                  >
+                    {getItemCount()}
+                  </span>
+                )}
+              </button>
+              <button
+                onClick={() => setTab('orders')}
+                className={cn(
+                  'flex-1 py-2 px-3 rounded-lg text-sm font-semibold transition-all duration-200 flex items-center justify-center gap-1.5',
+                  tab === 'orders'
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-500 hover:text-gray-700'
+                )}
+              >
+                Mi Pedido
+                <span className="relative flex h-2 w-2">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-50" />
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+                </span>
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="px-6 py-5 border-b flex items-center justify-between shrink-0">
+            <h2 className="text-lg font-bold flex items-center gap-2.5">
+              Tu Carrito
+              {getItemCount() > 0 && (
+                <span className="bg-(--color-primary) text-white text-[11px] font-bold px-2 py-0.5 rounded-full">
+                  {getItemCount()}
+                </span>
+              )}
+            </h2>
+            <button
+              onClick={onClose}
+              className="p-1.5 -mr-1.5 hover:bg-gray-100 rounded-lg transition-colors"
+              aria-label="Cerrar carrito"
+            >
+              <X size={20} className="text-gray-400" />
+            </button>
+          </div>
+        )}
 
-                      {/* Comment section */}
-                      {editingCommentId === item.product.id ? (
-                        <textarea
-                          autoFocus
-                          value={commentDraft}
-                          onChange={(e) => setCommentDraft(e.target.value)}
-                          onBlur={() => saveComment(item.product.id)}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter' && !e.shiftKey) {
-                              e.preventDefault();
-                              saveComment(item.product.id);
-                            }
-                            if (e.key === 'Escape') {
-                              setEditingCommentId(null);
-                            }
-                          }}
-                          placeholder="Agrega una nota..."
-                          rows={2}
-                          className="w-full text-xs text-muted-foreground border border-border rounded-md px-2 py-1 mb-2 resize-none focus:outline-none focus:ring-1 focus:ring-(--color-primary) bg-background"
-                        />
-                      ) : (
-                        <div className="flex items-start gap-1 mb-2 min-h-5">
-                          {item.comment && (
-                            <p className="text-xs text-muted-foreground italic line-clamp-1 flex-1">
-                              &quot;{item.comment}&quot;
-                            </p>
-                          )}
-                          <button
-                            onClick={() => startEditComment(item.product.id, item.comment)}
-                            className="text-muted-foreground/60 hover:text-(--color-primary) transition-colors shrink-0"
-                            aria-label="Editar comentario"
-                          >
-                            <Pencil size={12} />
-                          </button>
-                        </div>
-                      )}
-
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-3 bg-muted rounded-full p-1 border">
-                          <button
-                            onClick={() => updateQuantity(item.product.id, item.quantity - 1)}
-                            className="p-1 hover:bg-muted/80 rounded-full transition-colors"
-                            aria-label="Disminuir cantidad"
-                          >
-                            <Minus size={14} />
-                          </button>
-                          <span className="font-semibold text-sm min-w-3.5 text-center transition-all duration-200">
-                            {item.quantity}
-                          </span>
-                          <button
-                            onClick={() => updateQuantity(item.product.id, item.quantity + 1)}
-                            className="p-1 hover:bg-muted/80 rounded-full transition-colors"
-                            aria-label="Aumentar cantidad"
-                          >
-                            <Plus size={14} />
-                          </button>
-                        </div>
-                        <div className="text-right">
-                          <p className="text-xs text-muted-foreground">
-                            {formatPrice(item.product.price)} c/u
-                          </p>
-                          <span className="font-bold text-sm">
-                            {formatPrice(item.product.price * item.quantity)}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                ))}
+        {/* Content area */}
+        <div className="flex-1 overflow-hidden">
+          {tab === 'cart' ? (
+            /* Cart tab */
+            items.length === 0 ? (
+              <div className="h-full flex flex-col items-center justify-center p-8 text-center">
+                <div className="bg-muted p-6 rounded-full mb-4">
+                  <ShoppingBag size={48} className="text-muted-foreground/40" />
+                </div>
+                <h3 className="text-lg font-semibold mb-2">Tu carrito está vacío</h3>
+                <p className="text-muted-foreground mb-6">¿Hambre? ¡Agrega algo delicioso!</p>
+                <Button
+                  onClick={onClose}
+                  className="rounded-full bg-(--color-primary) hover:bg-(--color-primary) text-white opacity-90 hover:opacity-100 px-8"
+                >
+                  Volver al menú
+                </Button>
               </div>
-            </ScrollArea>
+            ) : (
+              <ScrollArea className="h-full px-6">
+                <div className="py-6 space-y-6">
+                  {items.map((item) => (
+                    <div key={item.product.id} className="flex gap-4">
+                      <div className="relative h-20 w-20 shrink-0">
+                        {item.product.imageUrl ? (
+                          <Image
+                            src={item.product.imageUrl}
+                            alt={item.product.name}
+                            fill
+                            className="object-cover rounded-lg"
+                          />
+                        ) : (
+                          <div className="h-full w-full bg-muted rounded-lg flex items-center justify-center text-muted-foreground text-xs">
+                            Sin imagen
+                          </div>
+                        )}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex justify-between items-start mb-1">
+                          <h4 className="font-semibold text-foreground truncate pr-2">
+                            {item.product.name}
+                          </h4>
+                          <button
+                            onClick={() => removeItem(item.product.id)}
+                            className="text-muted-foreground hover:text-red-500 transition-colors"
+                            aria-label="Eliminar producto"
+                          >
+                            <Trash2 size={16} />
+                          </button>
+                        </div>
+
+                        {/* Comment section */}
+                        {editingCommentId === item.product.id ? (
+                          <textarea
+                            autoFocus
+                            value={commentDraft}
+                            onChange={(e) => setCommentDraft(e.target.value)}
+                            onBlur={() => saveComment(item.product.id)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' && !e.shiftKey) {
+                                e.preventDefault();
+                                saveComment(item.product.id);
+                              }
+                              if (e.key === 'Escape') {
+                                setEditingCommentId(null);
+                              }
+                            }}
+                            placeholder="Agrega una nota..."
+                            rows={2}
+                            className="w-full text-xs text-muted-foreground border border-border rounded-md px-2 py-1 mb-2 resize-none focus:outline-none focus:ring-1 focus:ring-(--color-primary) bg-background"
+                          />
+                        ) : (
+                          <div className="flex items-start gap-1 mb-2 min-h-5">
+                            {item.comment && (
+                              <p className="text-xs text-muted-foreground italic line-clamp-1 flex-1">
+                                &quot;{item.comment}&quot;
+                              </p>
+                            )}
+                            <button
+                              onClick={() => startEditComment(item.product.id, item.comment)}
+                              className="text-muted-foreground/60 hover:text-(--color-primary) transition-colors shrink-0"
+                              aria-label="Editar comentario"
+                            >
+                              <Pencil size={12} />
+                            </button>
+                          </div>
+                        )}
+
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-3 bg-muted rounded-full p-1 border">
+                            <button
+                              onClick={() => updateQuantity(item.product.id, item.quantity - 1)}
+                              className="p-1 hover:bg-muted/80 rounded-full transition-colors"
+                              aria-label="Disminuir cantidad"
+                            >
+                              <Minus size={14} />
+                            </button>
+                            <span className="font-semibold text-sm min-w-3.5 text-center transition-all duration-200">
+                              {item.quantity}
+                            </span>
+                            <button
+                              onClick={() => updateQuantity(item.product.id, item.quantity + 1)}
+                              className="p-1 hover:bg-muted/80 rounded-full transition-colors"
+                              aria-label="Aumentar cantidad"
+                            >
+                              <Plus size={14} />
+                            </button>
+                          </div>
+                          <div className="text-right">
+                            <p className="text-xs text-muted-foreground">
+                              {formatPrice(item.product.price)} c/u
+                            </p>
+                            <span className="font-bold text-sm">
+                              {formatPrice(item.product.price * item.quantity)}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </ScrollArea>
+            )
+          ) : (
+            /* Orders tab */
+            slug && (
+              <OrderTrackingTab
+                activeOrders={activeOrders}
+                slug={slug}
+                basePath={basePath}
+                onClose={onClose}
+              />
+            )
           )}
         </div>
 
-        {items.length > 0 && (
-          <SheetFooter className="p-5 border-t bg-white sm:flex-col sm:space-x-0">
+        {/* Footer — only for cart tab when cart has items */}
+        {tab === 'cart' && items.length > 0 && (
+          <SheetFooter className="p-5 border-t bg-white sm:flex-col sm:space-x-0 shrink-0">
             <div className="space-y-3 w-full">
               <div className="flex items-center justify-between">
                 <span className="text-sm text-muted-foreground">Subtotal</span>
@@ -194,7 +295,7 @@ export function CartDrawer({ isOpen, onClose }: CartDrawerProps) {
               </div>
               <Link href={`${basePath}/checkout`} className="w-full block">
                 <Button
-                  className="w-full h-12 rounded-full bg-(--color-primary) hover:bg-(--color-primary) opacity-90 hover:opacity-100 text-base font-bold shadow-lg"
+                  className="w-full h-12 rounded-full bg-(--color-primary) hover:bg-(--color-primary) text-white opacity-90 hover:opacity-100 text-base font-bold shadow-lg"
                   onClick={onClose}
                 >
                   Continuar al pago

--- a/src/components/cart/OrderTrackingTab.tsx
+++ b/src/components/cart/OrderTrackingTab.tsx
@@ -1,0 +1,421 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import api from '@/lib/api';
+import { Order } from '@/types/order';
+import { ActiveOrder, clearActiveOrder, saveActiveOrder } from '@/lib/guest-orders';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { cn } from '@/lib/utils';
+import { formatPrice } from '@/lib/format';
+import {
+  Loader2,
+  ExternalLink,
+  Package,
+  Clock,
+  ChefHat,
+  CheckCircle2,
+  XCircle,
+  Search,
+  Plus,
+  Truck,
+} from 'lucide-react';
+import Image from 'next/image';
+
+interface OrderTrackingTabProps {
+  activeOrders: ActiveOrder[];
+  slug: string;
+  basePath: string;
+  onClose: () => void;
+}
+
+function getSteps(orderType: string) {
+  if (orderType === 'delivery') {
+    return [
+      { key: 'received', label: 'Recibido', icon: Clock },
+      { key: 'preparing', label: 'Preparando', icon: ChefHat },
+      { key: 'ready', label: 'Listo', icon: Package },
+      { key: 'on_the_way', label: 'En camino', icon: Truck },
+      { key: 'completed', label: 'Entregado', icon: CheckCircle2 },
+    ];
+  }
+  return [
+    { key: 'received', label: 'Recibido', icon: Clock },
+    { key: 'preparing', label: 'Preparando', icon: ChefHat },
+    { key: 'ready', label: 'Listo', icon: Package },
+    { key: 'completed', label: 'Entregado', icon: CheckCircle2 },
+  ];
+}
+
+const STATUS_CONFIG: Record<string, { label: string; color: string }> = {
+  awaiting_payment: { label: 'Esperando pago', color: 'bg-amber-100 text-amber-700' },
+  pending: { label: 'Recibido', color: 'bg-blue-100 text-blue-700' },
+  in_progress: { label: 'Preparando', color: 'bg-blue-100 text-blue-700' },
+  ready: { label: 'Listo', color: 'bg-emerald-100 text-emerald-700' },
+  out_for_delivery: { label: 'En camino', color: 'bg-purple-100 text-purple-700' },
+  completed: { label: 'Completado', color: 'bg-green-100 text-green-700' },
+  cancelled: { label: 'Cancelado', color: 'bg-red-100 text-red-700' },
+};
+
+const ITEM_STATUS_DOT: Record<string, string> = {
+  pending: 'bg-gray-300',
+  in_preparation: 'bg-blue-400',
+  ready: 'bg-emerald-500',
+  delivered: 'bg-gray-400',
+};
+
+const TERMINAL_STATUSES = new Set(['completed', 'cancelled']);
+
+function getStepIndex(order: Order): number {
+  if (order.status === 'cancelled') return -1;
+  if (order.status === 'completed') {
+    return order.type === 'delivery' ? 4 : 3;
+  }
+  if (order.status === 'out_for_delivery') return 3; // delivery only
+  if (order.status === 'ready') return 2;
+  if (order.status === 'pending' || order.status === 'awaiting_payment') return 0;
+  // in_progress
+  if (order.items?.some((i) => i.status === 'ready' || i.status === 'delivered')) return 2;
+  return 1;
+}
+
+function getStatusMessage(order: Order): string {
+  switch (order.status) {
+    case 'awaiting_payment':
+      return 'Verificando pago...';
+    case 'pending':
+      return 'Pedido recibido';
+    case 'in_progress': {
+      const ready = order.items?.filter((i) => i.status === 'ready' || i.status === 'delivered').length ?? 0;
+      if (ready > 0) return `${ready}/${order.items?.length} items listos`;
+      return 'En preparacion';
+    }
+    case 'ready':
+      return order.type === 'delivery'
+        ? 'Listo. Esperando repartidor.'
+        : order.type === 'pickup'
+          ? 'Listo para retirar.'
+          : 'Tu pedido está listo.';
+    case 'out_for_delivery':
+      return 'En camino.';
+    case 'completed':
+      return 'Completado';
+    case 'cancelled':
+      return 'Cancelado';
+    default:
+      return '';
+  }
+}
+
+/* ─── Compact Stepper ───────────────────────────────────────────────────── */
+
+type Step = ReturnType<typeof getSteps>[number];
+
+function CompactStepper({ steps, stepIndex }: { steps: Step[]; stepIndex: number }) {
+  return (
+    <div className="flex items-start w-full">
+      {steps.map((step, idx) => {
+        const isActive = idx <= stepIndex;
+        const isCurrent = idx === stepIndex;
+        const StepIcon = step.icon;
+        return (
+          <React.Fragment key={step.key}>
+            <div className="flex flex-col items-center gap-1">
+              <div
+                className={cn(
+                  'w-7 h-7 rounded-full flex items-center justify-center transition-all duration-300',
+                  isCurrent
+                    ? 'bg-(--color-primary) text-white'
+                    : isActive
+                      ? 'bg-(--color-primary)/15 text-(--color-primary)'
+                      : 'bg-gray-100 text-gray-300',
+                )}
+              >
+                <StepIcon size={12} />
+              </div>
+              <span
+                className={cn(
+                  'text-[9px] font-medium text-center leading-tight w-12',
+                  isActive ? 'text-gray-700' : 'text-gray-400',
+                )}
+              >
+                {step.label}
+              </span>
+            </div>
+            {idx < steps.length - 1 && (
+              <div className="flex-1 mt-3.5 mx-0.5">
+                <div className="h-px w-full bg-gray-100 rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-(--color-primary) rounded-full transition-all duration-500"
+                    style={{ width: idx < stepIndex ? '100%' : '0%' }}
+                  />
+                </div>
+              </div>
+            )}
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ─── Order Card ────────────────────────────────────────────────────────── */
+
+interface OrderCardProps {
+  activeOrder: ActiveOrder;
+  slug: string;
+  basePath: string;
+  onClose: () => void;
+}
+
+function OrderCard({ activeOrder, slug, basePath, onClose }: OrderCardProps) {
+  const { data: order, isLoading } = useQuery<Order>({
+    queryKey: ['order-tracking', slug, activeOrder.orderId],
+    queryFn: async () => {
+      const res = await api.get<Order>(
+        `/storefront/${slug}/orders/${activeOrder.orderId}`,
+      );
+      return res.data;
+    },
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status && TERMINAL_STATUSES.has(status) ? false : 10_000;
+    },
+    staleTime: 5_000,
+  });
+
+  useEffect(() => {
+    if (order && TERMINAL_STATUSES.has(order.status)) {
+      clearActiveOrder(activeOrder.orderId);
+    }
+  }, [order, activeOrder.orderId]);
+
+  if (isLoading) {
+    return (
+      <div className="rounded-2xl border border-gray-100 bg-white p-6 flex items-center justify-center h-28">
+        <Loader2 size={20} className="animate-spin text-gray-300" />
+      </div>
+    );
+  }
+
+  if (!order) return null;
+
+  const steps = getSteps(order.type);
+  const stepIndex = getStepIndex(order);
+  const statusConfig = STATUS_CONFIG[order.status] ?? { label: order.status, color: 'bg-gray-100 text-gray-600' };
+  const statusMessage = getStatusMessage(order);
+  const isCancelled = order.status === 'cancelled';
+  const orderNumber = order.orderNumber ?? order.id.slice(-8).toUpperCase();
+
+  return (
+    <div className="rounded-2xl border border-gray-100 bg-white overflow-hidden">
+      {/* Header */}
+      <div className="px-4 pt-4 pb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2.5">
+          <p className="text-sm font-black text-gray-900 font-mono tracking-wider">
+            #{orderNumber}
+          </p>
+          <span className={cn('text-[10px] font-semibold px-2 py-0.5 rounded-full', statusConfig.color)}>
+            {statusConfig.label}
+          </span>
+        </div>
+        <Link
+          href={`${basePath}/track/${order.id}`}
+          onClick={onClose}
+          className="flex items-center gap-1 text-xs font-semibold text-(--color-primary) hover:underline"
+        >
+          Ver
+          <ExternalLink size={10} />
+        </Link>
+      </div>
+
+      {/* Stepper or cancelled */}
+      <div className="px-4 pb-3">
+        {isCancelled ? (
+          <div className="flex items-center gap-2 py-2 px-3 bg-red-50 rounded-xl">
+            <XCircle size={14} className="text-red-500 shrink-0" />
+            <p className="text-xs font-medium text-red-700">Pedido cancelado</p>
+          </div>
+        ) : (
+          <>
+            <CompactStepper steps={steps} stepIndex={stepIndex} />
+            {statusMessage && (
+              <p className="text-[10px] text-gray-400 text-center mt-1.5">{statusMessage}</p>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Items summary */}
+      <div className="border-t border-gray-100">
+        {order.items.map((item) => (
+          <div
+            key={item.id}
+            className="flex items-center gap-2.5 px-4 py-2 border-b border-gray-50 last:border-b-0"
+          >
+            {item.productImage ? (
+              <div className="relative w-8 h-8 rounded-md overflow-hidden bg-gray-100 shrink-0">
+                <Image src={item.productImage} alt={item.productName ?? ''} fill className="object-cover" />
+              </div>
+            ) : (
+              <div className={cn('w-1.5 h-1.5 rounded-full shrink-0', ITEM_STATUS_DOT[item.status] ?? 'bg-gray-300')} />
+            )}
+            <p className="text-xs text-gray-700 flex-1 min-w-0 truncate">
+              <span className="font-semibold">{item.quantity}x</span> {item.productName ?? 'Producto'}
+            </p>
+            <p className="text-xs text-gray-400 font-medium shrink-0 tabular-nums">
+              {formatPrice(item.unitPrice * item.quantity)}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Total */}
+      <div className="px-4 py-2.5 bg-gray-50 flex items-center justify-between border-t border-gray-100">
+        <span className="text-xs text-gray-500 font-medium">Total</span>
+        <span className="text-sm font-bold text-gray-900">{formatPrice(order.total ?? 0)}</span>
+      </div>
+    </div>
+  );
+}
+
+/* ─── Add Order by Code ─────────────────────────────────────────────────── */
+
+function AddOrderByCode({ slug, basePath }: { slug: string; basePath: string }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+  const router = useRouter();
+
+  const handleSearch = async () => {
+    const trimmed = code.trim().toUpperCase();
+    if (trimmed.length < 4) {
+      setError('Minimo 4 caracteres');
+      return;
+    }
+
+    setError(null);
+    setIsSearching(true);
+
+    try {
+      const res = await api.get<{ id: string; orderNumber: string }>(
+        `/storefront/${slug}/orders/lookup`,
+        { params: { orderNumber: trimmed } },
+      );
+      // Save to localStorage so it appears in tracking
+      saveActiveOrder({
+        orderId: res.data.id,
+        orderNumber: res.data.orderNumber ?? trimmed,
+        slug,
+      });
+      setCode('');
+      setIsOpen(false);
+      setError(null);
+      // Force re-render by navigating to tracking
+      router.push(`${basePath}/track/${res.data.id}`);
+    } catch {
+      setError('Pedido no encontrado');
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  if (!isOpen) {
+    return (
+      <button
+        onClick={() => setIsOpen(true)}
+        className="w-full flex items-center justify-center gap-2 py-2.5 text-xs font-semibold text-gray-400 hover:text-gray-600 transition-colors"
+      >
+        <Plus size={14} />
+        Agregar pedido por codigo
+      </button>
+    );
+  }
+
+  return (
+    <div className="bg-gray-50 rounded-xl p-3 space-y-2">
+      <div className="flex gap-2">
+        <div className="relative flex-1">
+          <input
+            type="text"
+            value={code}
+            onChange={(e) => { setCode(e.target.value.toUpperCase()); setError(null); }}
+            placeholder="Ej: A1B2C3D4"
+            maxLength={8}
+            autoFocus
+            autoComplete="off"
+            autoCorrect="off"
+            spellCheck={false}
+            onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+            className="w-full h-9 px-3 rounded-lg border border-gray-200 text-sm font-mono font-bold tracking-widest text-gray-900 placeholder:text-gray-300 placeholder:tracking-normal placeholder:font-normal placeholder:text-xs focus:outline-none focus:ring-1 focus:ring-(--color-primary) bg-white"
+          />
+        </div>
+        <button
+          onClick={handleSearch}
+          disabled={isSearching || code.trim().length < 4}
+          className="h-9 px-3 rounded-lg bg-(--color-primary) text-white text-xs font-semibold hover:opacity-90 disabled:opacity-40 transition-all flex items-center gap-1.5 shrink-0"
+        >
+          {isSearching ? (
+            <Loader2 size={13} className="animate-spin" />
+          ) : (
+            <Search size={13} />
+          )}
+        </button>
+        <button
+          onClick={() => { setIsOpen(false); setCode(''); setError(null); }}
+          className="h-9 px-2 rounded-lg text-gray-400 hover:text-gray-600 text-xs font-medium transition-colors shrink-0"
+        >
+          Cancel
+        </button>
+      </div>
+      {error && <p className="text-xs text-red-500 px-1">{error}</p>}
+    </div>
+  );
+}
+
+/* ─── Tab ────────────────────────────────────────────────────────────────── */
+
+export function OrderTrackingTab({
+  activeOrders,
+  slug,
+  basePath,
+  onClose,
+}: OrderTrackingTabProps) {
+  if (activeOrders.length === 0) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center p-8 text-center">
+        <div className="bg-gray-100 p-5 rounded-full mb-4">
+          <Package size={36} className="text-gray-300" />
+        </div>
+        <h3 className="text-base font-bold text-gray-900 mb-1">
+          Sin pedidos activos
+        </h3>
+        <p className="text-sm text-gray-400 mb-5">
+          Agrega un pedido con su codigo para ver el estado.
+        </p>
+        <AddOrderByCode slug={slug} basePath={basePath} />
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className="h-full">
+      <div className="p-4 space-y-3">
+        {activeOrders.map((activeOrder) => (
+          <OrderCard
+            key={activeOrder.orderId}
+            activeOrder={activeOrder}
+            slug={slug}
+            basePath={basePath}
+            onClose={onClose}
+          />
+        ))}
+
+        <AddOrderByCode slug={slug} basePath={basePath} />
+      </div>
+    </ScrollArea>
+  );
+}

--- a/src/components/layout/ActiveOrderBanner.tsx
+++ b/src/components/layout/ActiveOrderBanner.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import { useRestaurant } from '@/providers/restaurant-provider';
+import { getActiveOrder, clearActiveOrder } from '@/lib/guest-orders';
+import { X, ChevronRight } from 'lucide-react';
+import { useAuthStore } from '@/stores/auth-store';
+import api from '@/lib/api';
+
+const STATUS_MAP: Record<string, { label: string; dot: string }> = {
+  awaiting_payment: { label: 'Esperando pago', dot: 'bg-amber-400' },
+  pending: { label: 'Recibido', dot: 'bg-blue-400' },
+  in_progress: { label: 'Preparando', dot: 'bg-blue-500' },
+  ready: { label: 'Listo', dot: 'bg-emerald-500' },
+};
+
+const DEFAULT_STATUS = { label: 'En curso', dot: 'bg-blue-400' };
+const TERMINAL_STATUSES = new Set(['completed', 'cancelled']);
+const POLL_MS = 15_000;
+
+export function ActiveOrderBanner() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { basePath, slug } = useRestaurant();
+  const { isAuthenticated } = useAuthStore();
+
+  const [hasMounted, setHasMounted] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const [orderStatus, setOrderStatus] = useState<string | null>(null);
+  const [visible, setVisible] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => { setHasMounted(true); }, []);
+
+  const activeOrder = hasMounted && slug ? getActiveOrder(slug) : null;
+
+  const stopPolling = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  const fetchStatus = useCallback(async () => {
+    if (!slug || !activeOrder) return;
+    try {
+      const res = await api.get<{ status: string }>(
+        `/storefront/${slug}/orders/${activeOrder.orderId}`,
+      );
+      const s = res.data.status;
+      setOrderStatus(s);
+      if (TERMINAL_STATUSES.has(s)) {
+        stopPolling();
+        clearActiveOrder(activeOrder.orderId);
+      }
+    } catch { /* silent */ }
+  }, [slug, activeOrder, stopPolling]);
+
+  useEffect(() => {
+    if (!hasMounted || !activeOrder) return;
+    fetchStatus();
+    intervalRef.current = setInterval(fetchStatus, POLL_MS);
+    return () => stopPolling();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasMounted, activeOrder?.orderId]);
+
+  // Entrance animation delay
+  useEffect(() => {
+    if (hasMounted && activeOrder && !dismissed) {
+      const t = setTimeout(() => setVisible(true), 300);
+      return () => clearTimeout(t);
+    }
+    setVisible(false);
+  }, [hasMounted, activeOrder, dismissed]);
+
+  if (!hasMounted) return null;
+  if (isAuthenticated) return null;
+  if (!activeOrder) return null;
+  if (pathname?.includes('/track/')) return null;
+  if (dismissed) return null;
+
+  const status = STATUS_MAP[orderStatus ?? 'pending'] ?? DEFAULT_STATUS;
+
+  return (
+    <>
+      {/* Mobile — pill above the cart button */}
+      <div
+        className={`
+          lg:hidden fixed bottom-20 left-4 right-4 z-50
+          transition-all duration-500 ease-out
+          ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4 pointer-events-none'}
+        `}
+      >
+        <button
+          onClick={() => router.push(`${basePath}/track/${activeOrder.orderId}`)}
+          className="
+            w-full flex items-center gap-3 px-4 py-3
+            bg-white rounded-2xl
+            shadow-[0_4px_24px_rgba(0,0,0,0.10)]
+            border border-gray-100
+            active:scale-[0.98] transition-transform
+          "
+        >
+          {/* Animated status dot */}
+          <span className="relative flex h-3 w-3 shrink-0">
+            <span className={`animate-ping absolute inline-flex h-full w-full rounded-full opacity-50 ${status.dot}`} />
+            <span className={`relative inline-flex rounded-full h-3 w-3 ${status.dot}`} />
+          </span>
+
+          {/* Info */}
+          <div className="flex-1 min-w-0 flex items-center gap-2">
+            <span className="text-sm font-bold text-gray-900 truncate">
+              {status.label}
+            </span>
+            <span className="text-xs text-gray-400 font-mono tracking-wider shrink-0">
+              #{activeOrder.orderNumber}
+            </span>
+          </div>
+
+          {/* Arrow */}
+          <ChevronRight size={16} className="text-gray-300 shrink-0" />
+
+          {/* Dismiss */}
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={(e) => { e.stopPropagation(); setDismissed(true); }}
+            onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); setDismissed(true); } }}
+            className="shrink-0 p-1 -mr-1 rounded-full text-gray-300 hover:text-gray-500 transition-colors"
+            aria-label="Cerrar"
+          >
+            <X size={14} />
+          </span>
+        </button>
+      </div>
+
+      {/* Desktop — floating pill above cart FAB */}
+      <div
+        className={`
+          hidden lg:block fixed bottom-24 right-6 z-50
+          transition-all duration-500 ease-out
+          ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4 pointer-events-none'}
+        `}
+      >
+        <button
+          onClick={() => router.push(`${basePath}/track/${activeOrder.orderId}`)}
+          className="
+            flex items-center gap-3 pl-4 pr-3 py-2.5
+            bg-white rounded-full
+            shadow-[0_8px_32px_rgba(0,0,0,0.12)]
+            border border-gray-100
+            hover:shadow-[0_8px_32px_rgba(0,0,0,0.18)]
+            hover:scale-[1.02] active:scale-[0.98]
+            transition-all duration-200
+          "
+        >
+          <span className="relative flex h-2.5 w-2.5 shrink-0">
+            <span className={`animate-ping absolute inline-flex h-full w-full rounded-full opacity-50 ${status.dot}`} />
+            <span className={`relative inline-flex rounded-full h-2.5 w-2.5 ${status.dot}`} />
+          </span>
+
+          <span className="text-sm font-semibold text-gray-900">
+            {status.label}
+          </span>
+          <span className="text-xs text-gray-400 font-mono tracking-wider">
+            #{activeOrder.orderNumber}
+          </span>
+
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={(e) => { e.stopPropagation(); setDismissed(true); }}
+            onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); setDismissed(true); } }}
+            className="p-1 rounded-full text-gray-300 hover:text-gray-500 transition-colors"
+            aria-label="Cerrar"
+          >
+            <X size={14} />
+          </span>
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/components/layout/StorefrontHeader.tsx
+++ b/src/components/layout/StorefrontHeader.tsx
@@ -39,7 +39,6 @@ export function StorefrontHeader() {
   // Use hasMounted for auth-dependent values to match server render
   const authed = hasMounted && isAuthenticated;
   const dineIn = hasMounted && isDineIn;
-
   const navLinks = useMemo(() => {
     if (dineIn) {
       return [
@@ -224,20 +223,12 @@ export function StorefrontHeader() {
                   </DropdownMenuContent>
                 </DropdownMenu>
               ) : (
-                <>
-                  <button
-                    onClick={() => router.push(`${basePath}/auth/login`)}
-                    className="px-4 py-1.5 text-sm font-semibold text-gray-500 hover:text-foreground rounded-full transition-colors"
-                  >
-                    Entrar
-                  </button>
-                  <button
-                    onClick={() => router.push(`${basePath}/auth/register`)}
-                    className="px-4 py-1.5 text-sm font-semibold text-white bg-(--color-primary) rounded-full hover:opacity-90 active:scale-[0.97] transition-all"
-                  >
-                    Registrarse
-                  </button>
-                </>
+                <button
+                  onClick={() => router.push(`${basePath}/auth/login`)}
+                  className="px-4 py-1.5 text-sm font-semibold text-white bg-(--color-primary) rounded-full hover:opacity-90 active:scale-[0.97] transition-all"
+                >
+                  Ingresar
+                </button>
               )}
             </div>
           )}

--- a/src/components/menu/FloatingCartButton.tsx
+++ b/src/components/menu/FloatingCartButton.tsx
@@ -6,6 +6,9 @@ import { useState, useEffect, useRef } from 'react';
 import { usePathname } from 'next/navigation';
 import { CartDrawer } from '@/components/cart/CartDrawer';
 import { formatPrice } from '@/lib/format';
+import { getActiveOrdersForSlug } from '@/lib/guest-orders';
+import { useRestaurant } from '@/providers/restaurant-provider';
+import { useAuthStore } from '@/stores/auth-store';
 
 export function FloatingCartButton() {
   const itemCount = useCartStore((state) => state.getItemCount());
@@ -15,6 +18,9 @@ export function FloatingCartButton() {
   const [hasMounted, setHasMounted] = useState(false);
   const prevCount = useRef(itemCount);
   const pathname = usePathname();
+
+  const { slug } = useRestaurant();
+  const { isAuthenticated } = useAuthStore();
 
   useEffect(() => { setHasMounted(true); }, []);
 
@@ -33,24 +39,35 @@ export function FloatingCartButton() {
 
   const isEmpty = itemCount === 0;
 
+  const hasActiveOrders = slug && !isAuthenticated
+    ? getActiveOrdersForSlug(slug).length > 0
+    : false;
+
   return (
     <>
-      {/* Mobile */}
-      <div className="lg:hidden fixed bottom-0 left-0 right-0 z-50 px-4 mb-[calc(0.75rem+env(safe-area-inset-bottom))]">
-        {isEmpty ? (
-          /* Empty: subtle icon-only pill */
-          <button
-            onClick={() => setIsDrawerOpen(true)}
-            className="ml-auto flex items-center justify-center w-14 h-14 rounded-full bg-primary/80 text-white shadow-lg active:scale-95 transition-all float-right"
-          >
-            <ShoppingCart size={22} />
-          </button>
-        ) : (
-          /* With items: full-width bar */
+      {/* Mobile: empty cart — small FAB bottom-right */}
+      {isEmpty && (
+        <button
+          onClick={() => setIsDrawerOpen(true)}
+          className="lg:hidden fixed bottom-4 right-4 z-50 flex items-center justify-center w-14 h-14 rounded-full bg-(--color-primary) text-white shadow-lg active:scale-95 transition-all opacity-80 mb-[env(safe-area-inset-bottom)]"
+        >
+          <ShoppingCart size={22} />
+          {hasActiveOrders && (
+            <span className="absolute top-0.5 right-0.5 flex h-3 w-3">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+              <span className="relative inline-flex rounded-full h-3 w-3 bg-emerald-500 border-2 border-white" />
+            </span>
+          )}
+        </button>
+      )}
+
+      {/* Mobile: cart with items — full-width bar */}
+      {!isEmpty && (
+        <div className="lg:hidden fixed bottom-0 left-0 right-0 z-50 px-4 mb-[calc(0.75rem+env(safe-area-inset-bottom))]">
           <button
             onClick={() => setIsDrawerOpen(true)}
             className={[
-              'w-full h-14 rounded-2xl',
+              'w-full h-14 rounded-2xl relative',
               'bg-(--color-primary) text-white shadow-2xl',
               'flex items-center justify-between px-4',
               'active:scale-[0.98] transition-all',
@@ -65,41 +82,48 @@ export function FloatingCartButton() {
             </div>
             <span className="text-sm font-bold tracking-wide">Ver pedido</span>
             <span className="text-sm font-bold shrink-0">{formatPrice(total)}</span>
+            {hasActiveOrders && (
+              <span className="absolute top-2 right-2 flex h-2.5 w-2.5">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-emerald-500" />
+              </span>
+            )}
           </button>
-        )}
-      </div>
+        </div>
+      )}
 
       {/* Desktop */}
-      <button
-        onClick={() => setIsDrawerOpen(true)}
-        className={[
-          'hidden lg:flex',
-          'fixed bottom-6 right-6 z-50',
-          'bg-(--color-primary) text-white rounded-full',
-          'shadow-[0_8px_32px_rgba(0,0,0,0.25)]',
-          'items-center',
-          'hover:scale-105 active:scale-95 transition-all',
-          isEmpty ? 'w-14 h-14 justify-center' : 'px-5 py-3 gap-3',
-          isPulsing ? 'scale-110' : '',
-        ].join(' ')}
-      >
-        {isEmpty ? (
-          <ShoppingCart size={22} />
-        ) : (
-          <>
-            <div className="relative">
-              <ShoppingCart size={22} />
-              <span className="absolute -top-2 -right-2 bg-white text-(--color-primary) text-xs font-bold w-5 h-5 rounded-full flex items-center justify-center border-2 border-(--color-primary)">
-                {itemCount}
-              </span>
-            </div>
-            <div className="flex flex-col items-start leading-none">
-              <span className="text-[10px] uppercase font-bold opacity-80">Ver pedido</span>
-              <span className="text-sm font-bold">{formatPrice(total)}</span>
-            </div>
-          </>
-        )}
-      </button>
+      <div className="hidden lg:block fixed bottom-6 right-6 z-50">
+        <button
+          onClick={() => setIsDrawerOpen(true)}
+          className={`flex items-center bg-(--color-primary) text-white rounded-full shadow-[0_8px_32px_rgba(0,0,0,0.25)] hover:scale-105 active:scale-95 transition-all relative ${
+            isEmpty ? 'w-14 h-14 justify-center' : 'px-5 py-3 gap-3'
+          } ${isPulsing ? 'scale-110' : ''}`}
+        >
+          {isEmpty ? (
+            <ShoppingCart size={22} />
+          ) : (
+            <>
+              <div className="relative">
+                <ShoppingCart size={22} />
+                <span className="absolute -top-2 -right-2 bg-white text-(--color-primary) text-xs font-bold w-5 h-5 rounded-full flex items-center justify-center border-2 border-(--color-primary)">
+                  {itemCount}
+                </span>
+              </div>
+              <div className="flex flex-col items-start leading-none">
+                <span className="text-[10px] uppercase font-bold opacity-80">Ver pedido</span>
+                <span className="text-sm font-bold">{formatPrice(total)}</span>
+              </div>
+            </>
+          )}
+          {hasActiveOrders && (
+            <span className="absolute -top-0.5 -right-0.5 flex h-3 w-3">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+              <span className="relative inline-flex rounded-full h-3 w-3 bg-emerald-500 border-2 border-white" />
+            </span>
+          )}
+        </button>
+      </div>
 
       <CartDrawer isOpen={isDrawerOpen} onClose={() => setIsDrawerOpen(false)} />
     </>

--- a/src/components/menu/ProductCard.tsx
+++ b/src/components/menu/ProductCard.tsx
@@ -96,7 +96,7 @@ export function ProductCard({ product }: ProductCardProps) {
               className={`hidden md:flex rounded-full transition-all duration-300 ${
                 justAdded
                   ? 'bg-green-500 hover:bg-green-500 text-white gap-1'
-                  : 'bg-(--color-primary) hover:bg-(--color-primary) opacity-90 hover:opacity-100'
+                  : 'bg-(--color-primary) hover:bg-(--color-primary) text-white opacity-90 hover:opacity-100'
               }`}
               onClick={handleAdd}
             >

--- a/src/components/menu/ProductModal.tsx
+++ b/src/components/menu/ProductModal.tsx
@@ -153,7 +153,7 @@ function ModalContent({
               className={`flex-1 h-11 rounded-full font-bold text-sm transition-all duration-300 ${
                 addedSuccess
                   ? 'bg-emerald-500 hover:bg-emerald-500 text-white scale-[1.02]'
-                  : 'bg-(--color-primary) hover:bg-(--color-primary) opacity-90 hover:opacity-100'
+                  : 'bg-(--color-primary) hover:bg-(--color-primary) text-white opacity-90 hover:opacity-100'
               }`}
               onClick={onAddToCart}
               disabled={addedSuccess}
@@ -215,7 +215,7 @@ function ModalContent({
               className={`flex-1 h-12 rounded-full font-bold text-sm transition-all duration-300 ${
                 addedSuccess
                   ? 'bg-emerald-500 hover:bg-emerald-500 text-white scale-[1.02]'
-                  : 'bg-(--color-primary) hover:bg-(--color-primary) opacity-90 hover:opacity-100'
+                  : 'bg-(--color-primary) hover:bg-(--color-primary) text-white opacity-90 hover:opacity-100'
               }`}
               onClick={onAddToCart}
               disabled={addedSuccess}
@@ -260,7 +260,7 @@ function ModalContent({
           className={`flex-1 h-12 rounded-full font-bold text-sm transition-all duration-300 ${
             addedSuccess
               ? 'bg-emerald-500 hover:bg-emerald-500 text-white scale-[1.02]'
-              : 'bg-(--color-primary) hover:bg-(--color-primary) opacity-90 hover:opacity-100'
+              : 'bg-(--color-primary) hover:bg-(--color-primary) text-white opacity-90 hover:opacity-100'
           }`}
           onClick={onAddToCart}
           disabled={addedSuccess}

--- a/src/hooks/useCreateOrder.ts
+++ b/src/hooks/useCreateOrder.ts
@@ -14,6 +14,7 @@ interface CreateOrderPayload {
   guestName?: string;
   guestEmail?: string;
   guestPhone?: string;
+  paymentMethod?: string;
 }
 
 export function useCreateOrder() {

--- a/src/lib/guest-orders.ts
+++ b/src/lib/guest-orders.ts
@@ -1,0 +1,48 @@
+const STORAGE_KEY = 'autorestro_active_orders';
+
+export interface ActiveOrder {
+  orderId: string;
+  orderNumber: string;
+  slug: string;
+}
+
+export function saveActiveOrder(order: ActiveOrder): void {
+  if (typeof window === 'undefined') return;
+  const existing = getActiveOrders();
+  // Avoid duplicates, keep newest first
+  const filtered = existing.filter(o => o.orderId !== order.orderId);
+  filtered.unshift(order);
+  // Max 5 active orders
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered.slice(0, 5)));
+}
+
+export function getActiveOrders(): ActiveOrder[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const data = localStorage.getItem(STORAGE_KEY);
+    if (!data) return [];
+    const parsed = JSON.parse(data);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function getActiveOrder(slug: string): ActiveOrder | null {
+  return getActiveOrdersForSlug(slug)[0] ?? null;
+}
+
+export function getActiveOrdersForSlug(slug: string): ActiveOrder[] {
+  return getActiveOrders().filter(o => o.slug === slug);
+}
+
+export function clearActiveOrder(orderId: string): void {
+  if (typeof window === 'undefined') return;
+  const existing = getActiveOrders();
+  const filtered = existing.filter(o => o.orderId !== orderId);
+  if (filtered.length === 0) {
+    localStorage.removeItem(STORAGE_KEY);
+  } else {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+  }
+}

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -2,17 +2,33 @@ export interface OrderItem {
   id: string;
   productId: string;
   productName?: string;
+  productImage?: string;
   quantity: number;
+  unitPrice: number;
   comment?: string;
   status: 'pending' | 'in_preparation' | 'ready' | 'delivered';
-  price: number;
+  price?: number; // keep for backward compat with existing pages
 }
 
 export interface Order {
   id: string;
+  orderNumber?: string;
   type: 'pickup' | 'delivery' | 'dine_in';
-  status: 'pending' | 'in_progress' | 'completed' | 'cancelled';
+  status: 'awaiting_payment' | 'pending' | 'in_progress' | 'ready' | 'out_for_delivery' | 'completed' | 'cancelled';
+  paymentStatus?: string;
+  paymentMethod?: string;
   items: OrderItem[];
   createdAt: string;
   total?: number;
+  guestName?: string;
+  guestEmail?: string;
+  guestPhone?: string;
+  table?: { id: string; tableNumber: number } | null;
+  transaction?: {
+    id: string;
+    externalId?: string;
+    status: string;
+    provider: string;
+  } | null;
+  restaurant?: { name: string; slug: string; logoUrl?: string };
 }


### PR DESCRIPTION
## Summary
- Fix guest checkout flow (paymentMethod in payload, Webpay POST redirect)
- Add public order tracking page with stepper, customer info, payment details
- Integrate order tracking into cart drawer with tabs (Carrito | Mi Pedido)
- Support multiple active orders in localStorage with auto-cleanup
- Add inline "add order by code" in tracking tab
- Update tracking UI for delivery orders (5-step stepper with "En camino")
- Add READY and OUT_FOR_DELIVERY status support across all tracking views
- Fix text-white on all primary-color buttons
- Simplify header navigation for guests

## Test plan
- [ ] Guest checkout: complete order → verify success screen + tracking link
- [ ] Webpay: verify redirect to confirm page → payment confirmed → tracking works
- [ ] Cart drawer: open → verify tabs when active order exists
- [ ] "Mi Pedido" tab: verify order card with stepper, items, total
- [ ] Add by code: enter order number → verify order loads in tab
- [ ] Delivery tracking: verify 5-step stepper (Recibido → Preparando → Listo → En camino → Entregado)
- [ ] FAB: verify pulsing dot when active order exists
- [ ] Email link: click "Ver estado" → verify tracking page loads + saves to localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)